### PR TITLE
Dead code lint

### DIFF
--- a/src/poggit/builder/ProjectBuilder.php
+++ b/src/poggit/builder/ProjectBuilder.php
@@ -24,6 +24,7 @@ use Phar;
 use poggit\builder\cause\V2BuildCause;
 use poggit\builder\lint\BuildResult;
 use poggit\builder\lint\CloseTagLint;
+use poggit\builder\lint\DeadCodeLint;
 use poggit\builder\lint\DirectStdoutLint;
 use poggit\builder\lint\InternalBuildError;
 use poggit\builder\lint\NonPsrLint;
@@ -412,6 +413,39 @@ abstract class ProjectBuilder {
             $currentLine += substr_count($currentCode, "\n");
 
             if($tokenId === T_WHITESPACE) continue;
+
+            if(isset($lastTerminator, $lastTerminatorActive)) {
+                if(isset($lastTerminator_pendingColon)) {
+                    if(!($tokenId === -1 and trim($currentCode) === ":")) {
+                        $status = new DeadCodeLint();
+                        $status->file = $iteratedFile;
+                        $status->line = $currentLine;
+                        $status->ctrl = strtolower(substr(token_name($lastTerminator), 2));
+                        $status->code = $lines[$currentLine - 1] ?? "";
+                        $result->addStatus($status);
+                    }
+                    unset($lastTerminator);
+                    unset($lastTerminatorActive);
+                    unset($lastTerminator_pendingColon);
+                } else {
+                    if($tokenId === T_CASE or ($tokenId === -1 and trim($curentCode) === "}")) {
+                        unset($lastTerminator);
+                        unset($lastTerminatorActive);
+                    } elseif($tokenId === T_STRING) {
+                        $lastTerminator_pendingColon = true;
+                    } else {
+                        $status = new DeadCodeLint();
+                        $status->file = $iteratedFile;
+                        $status->line = $currentLine;
+                        $status->ctrl = strtolower(substr(token_name($lastTerminator), 2));
+                        $status->code = $lines[$currentLine - 1] ?? "";
+                        $result->addStatus($status);
+                        unset($lastTerminator);
+                        unset($lastTerminatorActive);
+                    }
+                }
+            }
+
             if($tokenId === T_STRING) {
                 if(isset($buildingNamespace)) {
                     $buildingNamespace .= trim($currentCode);
@@ -431,6 +465,9 @@ abstract class ProjectBuilder {
                 if(trim($currentCode) === ";" || trim($currentCode) === "{" and isset($buildingNamespace)) {
                     $namespaces[] = $currentNamespace = $buildingNamespace;
                     unset($buildingNamespace);
+                }
+                if(isset($lastTerminator) and trim($currentCode) === ";") {
+                    $lastTerminatorActive = true;
                 }
             } elseif($tokenId === T_CLOSE_TAG) {
                 $status = new CloseTagLint();
@@ -456,11 +493,14 @@ abstract class ProjectBuilder {
                     $status->isHtml = true;
                 } else {
                     $status->code = $lines[$currentLine - 1] ?? "";
-                    $status->hlSects = [$hlSectsPos = stripos($status->code, "echo"), $hlSectsPos + 2];
+                    $status->hlSects[] = [$hlSectsPos = stripos($status->code, "echo"), $hlSectsPos + 2];
                     $status->isHtml = false;
                 }
                 $status->isFileMain = $isFileMain;
                 $result->addStatus($status);
+            } elseif($tokenId === T_RETURN or $tokenId === T_BREAK or $tokenId === T_CONTINUE or $tokenId === T_GOTO or $tokenId === T_THROW or $tokenId === T_EXIT) { // actually, T_EXIT should not exit in plugins, but it might or might not be valid in some threads
+                // TODO confirm that this is not a short block syntax like `if($foo) return;`
+                $lastTerminator = $tokenId;
             }
         }
         foreach($classes as list($namespace, $class, $line)) {
@@ -469,7 +509,7 @@ abstract class ProjectBuilder {
                 $status->file = $iteratedFile;
                 $status->line = $line;
                 $status->code = $lines[$line - 1] ?? "";
-                $status->hlSects = [$classPos = strpos($status->code, $class), $classPos + 2];
+                $status->hlSects[] = [$classPos = strpos($status->code, $class), $classPos + 2];
                 $status->class = $namespace . "\\" . $class;
                 $result->addStatus($status);
             }

--- a/src/poggit/builder/lint/DeadCodeLint.php
+++ b/src/poggit/builder/lint/DeadCodeLint.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Poggit
+ *
+ * Copyright (C) 2016-2017 Poggit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace poggit\builder\lint;
+
+class DeadCodeLint extends BadPracticeLint {
+    /** @var string */
+    public $ctrl;
+
+    public function problemAsNounPhrase(): string {
+        return "Dead code";
+    }
+
+    public function moreElaboration() {
+        ?>
+        <p>The code above is placed behind a <code class="code"><?= $this->ctrl ?></code> statement, which terminates code flow in the block. Without appropriate entry points (e.g. <code>goto</code> labels, switch block <code>case</code>s, it is impossible that this line of code is run. While keeping this line does not affect performance or functionality, it is inappropriate to keep redundant code that would only decrease code readability. You are hence strongly recommended to delete this line, had it not been caused by misplacement of code.</p>
+        <?php
+    }
+}


### PR DESCRIPTION
Known issue 1: short control syntax will also be detected as dead code:

```php
if($proposition)
  return;
live_code(); // detected as dead code
```

Known issue 2: does not detect if recursion is involved, as simple as this:

```php
return function() {
  i_have_semicolon_behind_me();
};
dead_code(); // not detected as dead code
```