### PR TITLE
Fix for github release build compare links

### DIFF
--- a/src/poggit/release/details/ReleaseDetailsModule.php
+++ b/src/poggit/release/details/ReleaseDetailsModule.php
@@ -304,7 +304,7 @@ INNER JOIN users u ON rv.user = u.uid WHERE  rv.releaseId = ? and rv.vote = -1",
         $this->description = $this->release["description"] ? file_get_contents(ResourceManager::getInstance()->getResource($this->release["description"])) : "No Description";
         $this->version = $this->release["version"];
         $this->shortDesc = $this->release["shortDesc"];
-        $this->licenseDisplayStyle = (($this->release["license"]) === "custom") ? "display: true" : "display: none";
+        $this->licenseDisplayStyle = ($this->release["license"] === "custom") ? "display: true" : "display: none";
         $this->licenseText = $this->release["licenseRes"] ? file_get_contents(ResourceManager::getInstance()->getResource($this->release["licenseRes"])) : "";
         $this->license = $this->release["license"];
         if($this->release["changelog"]) {


### PR DESCRIPTION
This fixes issues with compare links, and also only shows compare links for builds actually visible to the user - i.e the plugin owner and staff see compare links to all previous release builds, and other users only see compare between publicly visible release builds.