### PR TITLE
Version specific reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I wanted to use this project as a way to experiment how bad it is if no framewor
 ### Poggit-CI: plugin builder
 Poggit will build phars for your project when you push a commit or make a pull request.
 
-Login on the [Poggit website](https://poggit.pmmp.io) and authorize the Poggit application for your user account or your organizations. You can find buttons to enable Poggit-CI for particular repos at [https://poggit.pmmp.io/ci](the CI admin panel). Poggit will help you create the file `.poggit.yml` in your repo, and then Poggit will start building your projects in your repo every commit.
+Login on the [Poggit website](https://poggit.pmmp.io) and authorize the Poggit application for your user account or your organizations. You can find buttons to enable Poggit-CI for particular repos at [the CI admin panel](https://poggit.pmmp.io/ci). Poggit will help you create the file `.poggit.yml` in your repo, and then Poggit will start building your projects in your repo every commit.
 
 ### Poggit-Release: plugin list
 A project can be released after it has a development build. You can find the release button in the CI project page.

--- a/src/poggit/errdoc/InternalErrorPage.php
+++ b/src/poggit/errdoc/InternalErrorPage.php
@@ -47,7 +47,7 @@ class InternalErrorPage extends Module {
       <div id="body">
         <h1>500 Internal Server Error</h1>
         <p>A server internal error occurred. Please use this request ID for reference if you need support:
-          <code class="code"><?= htmlspecialchars($_REQUEST["id"], ENT_QUOTES, 'UTF-8') ?? htmlspecialchars(Meta::getRequestId(), ENT_QUOTES, 'UTF-8') ?></code></p>
+          <code class="code"><?= htmlspecialchars($_REQUEST["id"] ?? Meta::getRequestId(), ENT_QUOTES, 'UTF-8') ?></code></p>
         <p>Logging out may solve the problem.
           <span class="action" onclick="location.assign('<?= Meta::root() ?>logout')">Have a try</span></p>
         <a class="twitter-timeline" data-width="350" data-height="600" data-theme="light" data-link-color="#E81C4F"

--- a/src/poggit/release/Release.php
+++ b/src/poggit/release/Release.php
@@ -346,7 +346,7 @@ class Release {
                 INNER JOIN releases rel ON rel.releaseId = release_reviews.releaseId
                 INNER JOIN projects p ON p.projectId = rel.projectId
                 INNER JOIN repos r ON r.repoId = p.repoId
-                WHERE rel.projectId = ? AND rel.state > 1 AND release_reviews.user <> r.accessWith", "i", $projectId);
+                WHERE rel.projectId = ? AND release_reviews.releaseId = ? AND rel.state > 1 AND release_reviews.user <> r.accessWith", "ii", $projectId, $releaseId);
         $totalDl = Mysql::query("SELECT SUM(rsr.dlCount) AS totalDl FROM resources rsr
                 INNER JOIN releases rel ON rel.projectId = ?
                 WHERE rsr.resourceId = rel.artifact AND state >= ?", "ii", $projectId, Release::STATE_CHECKED);

--- a/src/poggit/release/details/ReleaseDetailsModule.php
+++ b/src/poggit/release/details/ReleaseDetailsModule.php
@@ -642,7 +642,7 @@ INNER JOIN users u ON rv.user = u.uid WHERE  rv.releaseId = ? and rv.vote = -1",
                     </div>
                   </div>
                 <?php }
-                PluginReview::displayReleaseReviews([$this->release["projectId"]])
+                PluginReview::displayReleaseReviews([$this->release["projectId"]], $this->release["releaseId"])
                 ?>
             </div>
             <div class="plugin-meta-info">

--- a/src/poggit/release/details/review/PluginReview.php
+++ b/src/poggit/release/details/review/PluginReview.php
@@ -83,7 +83,7 @@ class PluginReview {
         return count($uid) > 0 ? $uid[0]["uid"] : 0;
     }
 
-    public static function displayReleaseReviews(array $projectIds, bool $showRelease = false, int $limit = 50) {
+    public static function displayReleaseReviews(array $projectIds, string $releaseId, bool $showRelease = false, int $limit = 50) {
         $types = str_repeat("i", count($projectIds));
         $relIdPhSet = substr(str_repeat(",?", count($projectIds)), 1);
         /** @var PluginReview[] $reviews */
@@ -93,7 +93,7 @@ class PluginReview {
                 FROM release_reviews rr INNER JOIN releases r ON rr.releaseId = r.releaseId
                 INNER JOIN users rau ON rau.uid = rr.user
                 INNER JOIN projects p ON r.projectId = p.projectId
-                WHERE p.projectId IN ($relIdPhSet)
+                WHERE p.projectId IN ($relIdPhSet) AND rr.releaseId = $releaseId
                 ORDER BY r.releaseId DESC, rr.created DESC LIMIT $limit", $types, ...$projectIds) as $row) {
             $review = new self();
             $review->releaseRepoId = (int) $row["repoId"];

--- a/src/poggit/release/details/review/PluginReview.php
+++ b/src/poggit/release/details/review/PluginReview.php
@@ -83,7 +83,7 @@ class PluginReview {
         return count($uid) > 0 ? $uid[0]["uid"] : 0;
     }
 
-    public static function displayReleaseReviews(array $projectIds, string $releaseId, bool $showRelease = false, int $limit = 50) {
+    public static function displayReleaseReviews(array $projectIds, int $releaseId, bool $showRelease = false, int $limit = 50) {
         $types = str_repeat("i", count($projectIds));
         $relIdPhSet = substr(str_repeat(",?", count($projectIds)), 1);
         /** @var PluginReview[] $reviews */


### PR DESCRIPTION
This is aimed at #168 

This PR does not 'override' the old reviews but simply separates them to only show when the version they reviewed is being looked at.
This changes:
- The star rating count/avg on release list to show only the latest version avg/count.
- The reviews and reply's shown when viewing a specific plugin/version.

This has been tested on multiple versions of a plugin see below for pictures.