### PR TITLE
Fix state change discord error.

### DIFF
--- a/src/poggit/release/details/ReleaseStateChangeAjax.php
+++ b/src/poggit/release/details/ReleaseStateChangeAjax.php
@@ -125,7 +125,7 @@ class ReleaseStateChangeAjax extends AjaxModule {
                         "fields" => [
                             [
                                 "name" => "Message",
-                                "value" => $_POST["message"],
+                                "value" => substr($_POST["message"],0,1024),
                             ],
                         ]
                     ];


### PR DESCRIPTION
Fixes `Error executing discord webhook: {"embeds": ["0"]}` when changing a state of a plugin with a message bigger then 1024 chars.