### PR TITLE
Correctly handle missing dependency

### DIFF
--- a/src/poggit/release/submit/SubmitFormAjax.php
+++ b/src/poggit/release/submit/SubmitFormAjax.php
@@ -582,7 +582,7 @@ EOD
                 $detectedDeps[$row["name"]] = $row;
             }
             foreach($detectedDeps as $name => $data) {
-                if($data === true) $this->errorBadRequest("The plugin requires the dependency \"$name\", but it does not exist");
+                if($data === true) $this->exitBadRequest("This plugin requires the dependency \"$name\", but it is not a released plugin on poggit.");
                 if($data === false) unset($detectedDeps[$name]);
             }
         }


### PR DESCRIPTION
Aimed directly at #207 where trying to view submit form for a plugin with a dependency not on poggit would result in the standard 500 page with no actual error being thrown.
Changed this behaviour to take advantage of the built in 404 Not found in SubmitFormAjax.php to tell user that their dependency cannot be found.

Commit used to test release: https://github.com/JaxkDev/PoggitTestPlugin/commit/f6a0b4b469acb014cdcc457a35d7154dcb4bc137

(Any plugin can be tested where depend[] includes a non-existing plugin name.)

(ignore dark theme)

Before:
![image](https://user-images.githubusercontent.com/25908768/74564856-e32fae00-4f67-11ea-9304-b36d72603933.png)

After:
![image](https://user-images.githubusercontent.com/25908768/74564710-94821400-4f67-11ea-91f1-67d6bf174daf.png)
