### PR TITLE
PHPStan 'dependency' update

### DIFF
--- a/src/poggit/ci/RepoZipball.php
+++ b/src/poggit/ci/RepoZipball.php
@@ -244,4 +244,8 @@ class RepoZipball {
             }
         }
     }
+
+    public function getZipPath(): string{
+        return $this->file;
+    }
 }

--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -333,7 +333,7 @@ class DefaultProjectBuilder extends ProjectBuilder {
                     return;
 
                 case 7:
-                    if(substr($stderr, 0, 11) === "Parse error") {
+                    if(substr($stderr, 0, 11) === "Parse error" || substr($stderr, 0, 11) === "Fatal error") {
                         $status = new PhpstanLint();
                         $status->message = str_replace("/source/", "", $stderr);
                         $result->addStatus($status);

--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -258,7 +258,7 @@ class DefaultProjectBuilder extends ProjectBuilder {
             $pluginPath = "/".trim($project->path,"/");
             $pluginInternalPath = $zipball->getZipPath();
 
-            Lang::myShellExec("docker create -e PLUGIN_PATH={$pluginPath} --name {$id} jaxkdev/poggit-phpstan:0.2.0", $stdout, $stderr, $exitCode);
+            Lang::myShellExec("docker create -e PLUGIN_PATH={$pluginPath} --name {$id} pmmp/poggit-phpstan:0.2.0", $stdout, $stderr, $exitCode);
 
             if($exitCode !== 0) {
                 $status = new PhpstanInternalError();

--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -255,7 +255,7 @@ class DefaultProjectBuilder extends ProjectBuilder {
         }
 
         try {
-            $pluginPath = "/".$project->path;
+            $pluginPath = "/".trim($project->path,"/");
             $pluginInternalPath = $zipball->getZipPath();
 
             Lang::myShellExec("docker create -e PLUGIN_PATH={$pluginPath} --name {$id} jaxkdev/poggit-phpstan:0.2.0", $stdout, $stderr, $exitCode);

--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -258,6 +258,12 @@ class DefaultProjectBuilder extends ProjectBuilder {
             $pluginPath = "/".trim($project->path,"/");
             $pluginInternalPath = $zipball->getZipPath();
 
+            if($pluginPath !== "/") $pluginPath .= "/";
+            /*
+             * PluginPath should be '/' when in no directory or '/Dir1/Dir2/etc/' when in directory's
+             * (notice beginning '/' and end '/')
+             */
+
             Lang::myShellExec("docker create --cpus=1 --memory=256M -e PLUGIN_PATH={$pluginPath} --name {$id} pmmp/poggit-phpstan:0.2.0", $stdout, $stderr, $exitCode);
 
             if($exitCode !== 0) {
@@ -314,11 +320,15 @@ class DefaultProjectBuilder extends ProjectBuilder {
 
                 case 3:
                     Meta::getLog()->e("Failed to extract plugin, Status: 3, stderr: {$stderr}");
+                    $status = new PhpstanInternalError();
+                    $status->exception = "PHPStan failed with ID '{$id}', Failed to extract the plugin. Contact support with the ID for help if this persists.";
+                    $result->addStatus($status);
+                    return;
 
                 case 4:
                     Meta::getLog()->e("Failed to extract dependency's, Status: 4, stderr: {$stderr}");
                     $status = new PhpstanInternalError();
-                    $status->exception = "PHPStan failed with ID '{$id}', contact support with the ID for help if this persists.";
+                    $status->exception = "PHPStan failed with ID '{$id}', Failed to extract dependency's. Contact support with the ID for help if this persists.";
                     $result->addStatus($status);
                     return;
 


### PR DESCRIPTION
As discovered phpstan + viruses just doesnt work well by default and left several plugins with over 50 problems...

So instead of using the built phar + injected viruses under same namespace the container now uses the repo zipball and any plugin/virion dependency's are now all located in /deps
