### PR TITLE
Implemented dyncmdlist docker container.

### DIFF
--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -52,7 +52,7 @@ class DefaultProjectBuilder extends ProjectBuilder {
         return "2.0";
     }
 
-    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project): BuildResult {
+    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project, int $buildId): BuildResult {
         $this->project = $project;
         $this->tempFile = Meta::getTmpFile(".php");
         $result = new BuildResult();
@@ -178,6 +178,10 @@ class DefaultProjectBuilder extends ProjectBuilder {
             return implode("\\", array_slice(explode("\\", $mainClass), 0, -1)) . "\\";
         });
 
+        $phar->stopBuffering();
+        $this->runDynamicCommandList($phar->getPath(), yaml_parse($pluginYml)["name"] ?? null, $buildId);
+        $phar->startBuffering();
+
         if(!($doLint)){
             echo "Lint & PHPStan skipped.\n";
             return $result;
@@ -193,6 +197,65 @@ class DefaultProjectBuilder extends ProjectBuilder {
         }
 
         return $result;
+    }
+
+    private function runDynamicCommandList(string $pharPath, string $pluginName, int $buildId){
+        if($pluginName === null){
+            Meta::getLog()->e("Failed to start dyncmdlist, no plugin name found.");
+            return;
+        }
+
+        $id = "dyncmdlist-" . substr(Meta::getRequestId() ?? bin2hex(random_bytes(8)), 0, 4) . "-" . bin2hex(random_bytes(4));
+
+        Meta::getLog()->v("Starting dyncmdlist flow with ID '{$id}'");
+
+        Lang::myShellExec("docker run --name {$id} --cpus=1 --memory=256M -v ${pharPath}:/input/plugin.phar pmmp/dyncmdlist:0.1.1 ./wrapper.sh ${pluginName}", $stdout, $stderr, $exitCode);
+
+        if($exitCode !== 0){
+            Meta::getLog()->e("dyncmdlist failed with code '{$exitCode}', stdout: {$stdout}, stderr: {$stderr}");
+            return;
+        }
+
+        $result = json_decode($stdout, true);
+
+        if($result === null || !isset($result["status"])){
+            Meta::getLog()->e("Failed to parse results from dyncmdlist, stdout: {$stdout}, stderr: {$stderr}");
+            return;
+        }
+
+        if($result["status"] === false){
+            Meta::getLog()->e("dyncmdlist failed with error '{$result["error"]}'");
+            return;
+        }
+
+        if(sizeof($result["commands"]) === 0) {
+            Meta::getLog()->v("dyncmdlist found no commands.");
+            return;
+        }
+
+        foreach($result["commands"] as $cmd){
+            Mysql::query("INSERT INTO known_commands (name, description, `usage`, class, buildId) VALUES (?,?,?,?,?);",
+                "ssssi",
+                $cmd["name"],
+                $cmd["description"],
+                $cmd["usage"],
+                $cmd["class"],
+                $buildId
+            );
+            $count = sizeof($cmd["aliases"]);
+            $params = [];
+            foreach($cmd["aliases"] as $alias){
+                $params[] = $cmd["name"];
+                $params[] = $buildId;
+                $params[] = $alias;
+            }
+            if($count !== 0) {
+                Mysql::query("INSERT INTO known_aliases (name, buildId, alias) VALUES ".substr(str_repeat("(?,?,?),", $count), 0, -1),
+                    str_repeat("sis", $count),
+                    ...$params
+                );
+            }
+        }
     }
 
     private function runPhpstan(RepoZipball $zipball, BuildResult $result, WebhookProjectModel $project){

--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -179,7 +179,7 @@ class DefaultProjectBuilder extends ProjectBuilder {
         });
 
         $phar->stopBuffering();
-        $this->runDynamicCommandList(escapeshellarg($phar->getPath()), yaml_parse($pluginYml)["name"] ?? null, $buildId);
+        $this->runDynamicCommandList($phar->getPath(), yaml_parse($pluginYml)["name"] ?? null, $buildId);
         $phar->startBuffering();
 
         if(!($doLint)){
@@ -205,12 +205,13 @@ class DefaultProjectBuilder extends ProjectBuilder {
             return;
         }
         $pluginName = escapeshellarg($pluginName);
+        $pharPath = escapeshellarg($pharPath);
 
         $id = escapeshellarg("dyncmdlist-" . substr(Meta::getRequestId() ?? bin2hex(random_bytes(8)), 0, 4) . "-" . bin2hex(random_bytes(4)));
 
         Meta::getLog()->v("Starting dyncmdlist flow with ID '{$id}'");
 
-        Lang::myShellExec("docker run --rm --name {$id} --cpus=1 --memory=256M -v ${pharPath}:/input/plugin.phar pmmp/dyncmdlist:0.1.1 ./wrapper.sh ${pluginName}", $stdout, $stderr, $exitCode);
+        Lang::myShellExec("docker run --rm --name {$id} --cpus=1 --memory=256M -v {$pharPath}:/input/plugin.phar pmmp/dyncmdlist:0.1.1 ./wrapper.sh ${pluginName}", $stdout, $stderr, $exitCode);
 
         if($exitCode !== 0){
             Meta::getLog()->e("dyncmdlist failed with code '{$exitCode}', stdout: {$stdout}, stderr: {$stderr}");

--- a/src/poggit/ci/builder/NowHereProjectBuilder.php
+++ b/src/poggit/ci/builder/NowHereProjectBuilder.php
@@ -49,7 +49,7 @@ class NowHereProjectBuilder extends ProjectBuilder {
         return "2.0";
     }
 
-    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project): BuildResult {
+    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project, int $buildId): BuildResult {
         $this->project = $project;
         $this->tempFile = Meta::getTmpFile(".php");
 

--- a/src/poggit/ci/builder/PoggitVirionBuilder.php
+++ b/src/poggit/ci/builder/PoggitVirionBuilder.php
@@ -50,7 +50,7 @@ class PoggitVirionBuilder extends ProjectBuilder {
         return "1.0";
     }
 
-    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project): BuildResult {
+    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project, int $buildId): BuildResult {
         $this->project = $project;
         $this->tempFile = Meta::getTmpFile(".php");
         $result = new BuildResult();

--- a/src/poggit/ci/builder/ProjectBuilder.php
+++ b/src/poggit/ci/builder/ProjectBuilder.php
@@ -328,7 +328,7 @@ MESSAGE
         $phar->setMetadata($metadata);
 
         try {
-            $buildResult = $this->build($phar, $zipball, $project);
+            $buildResult = $this->build($phar, $zipball, $project, $buildId);
             if($buildResult->worstLevel === BuildResult::LEVEL_BUILD_ERROR) {
                 $phar->stopBuffering();
                 goto errored;
@@ -523,7 +523,7 @@ MESSAGE
 
     public abstract function getVersion(): string;
 
-    protected abstract function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project): BuildResult;
+    protected abstract function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project, int $buildId): BuildResult;
 
     public static function normalizeProjectPath(string $path): string {
         $path = trim($path, "/");

--- a/src/poggit/ci/builder/SpoonBuilder.php
+++ b/src/poggit/ci/builder/SpoonBuilder.php
@@ -40,7 +40,7 @@ class SpoonBuilder extends ProjectBuilder {
         return "1.0";
     }
 
-    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project): BuildResult {
+    protected function build(Phar $phar, RepoZipball $zipball, WebhookProjectModel $project, int $buildId): BuildResult {
         $this->project = $project;
         $this->tempFile = Meta::getTmpFile(".php");
         $result = new BuildResult();


### PR DESCRIPTION
As requested here's the dynamic command list implementation,
Runs the docker image on every build that is able to produce a phar.
If the plugin is able to load&enable on server startup it will have its commands and aliases gathered and recorded.