### PR TITLE
No-Cache

### DIFF
--- a/src/poggit/webhook/PushHandler.php
+++ b/src/poggit/webhook/PushHandler.php
@@ -71,7 +71,7 @@ class PushHandler extends WebhookHandler {
 
         $branch = self::refToBranch($this->data->ref);
         $zero = 0;
-        $zipball = new RepoZipball("repos/$repo->full_name/zipball/" . urlencode($branch), $repoInfo["token"], "repos/$repo->full_name", $zero, null, Meta::getMaxZipballSize($repo->id));
+        $zipball = new RepoZipball("repos/$repo->full_name/zipball/" . urlencode($this->data->after), $repoInfo["token"], "repos/$repo->full_name", $zero, null, Meta::getMaxZipballSize($repo->id));
 
         $manifestFile = ".poggit.yml";
         if(!$zipball->isFile($manifestFile)) {


### PR DESCRIPTION
Github cache's the branch's zipballs for quite some time around 2-3min, by using the commit ID we can be sure it cannot be cached and always up to date.

I cannot be sure if this is usable with the PR handler.