### PR TITLE
Auto-Update docker image

### DIFF
--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -385,7 +385,14 @@ class DefaultProjectBuilder extends ProjectBuilder {
              * (notice beginning '/' and end '/')
              */
 
-            Lang::myShellExec("docker create --cpus=1 --memory=256M -e PLUGIN_PATH={$pluginPath} --name {$id} pmmp/poggit-phpstan:0.2.1", $stdout, $stderr, $exitCode);
+			// Updates the latest tag if newer version available on hub.
+            Lang::myShellExec("docker pull pmmp/poggit-phpstan", $stdout, $stderr, $exitCode);
+
+            if($exitCode !== 0){
+                Meta::getLog()->e("Failed to update image pmmp/poggit-phpstan, Status: {$exitCode}, stderr: {$stderr}");
+            }
+
+            Lang::myShellExec("docker create --cpus=1 --memory=256M -e PLUGIN_PATH={$pluginPath} --name {$id} pmmp/poggit-phpstan:latest", $stdout, $stderr, $exitCode);
 
             if($exitCode !== 0) {
                 $status = new PhpstanInternalError();


### PR DESCRIPTION
Pull the latest image if a update is found.
- Allows poggit to run the latest PMMP API (around 2-10min after pmmp is updated on docker)
- Fully automated (Using docker hubs auto-build)

(Untested, this should in theory update when pmmp does)
![image](https://user-images.githubusercontent.com/25908768/84496053-298de300-aca4-11ea-82bf-e86c987756fa.png)
