### PR TITLE
Auto update docker images.

### DIFF
--- a/src/modules.php
+++ b/src/modules.php
@@ -96,6 +96,7 @@ use poggit\release\submit\ValidateReleaseNameAjax;
 use poggit\release\submit\ValidateReleaseVersionAjax;
 use poggit\resource\ResourceGetModule;
 use poggit\webhook\GitHubWebhookModule;
+use poggit\webhook\DockerWebhookModule;
 
 register_module("api", ApiModule::class);
 register_module("csrf", CsrfModule::class);
@@ -191,6 +192,8 @@ register_module("rule.add.ajax", RulesAddAjax::class);
 register_module("spoon.edit", SpoonEditModule::class);
 register_module("spoon.edit.ajax", SpoonEditAjax::class);
 register_module("spoon.add.ajax", SpoonAddAjax::class);
+
+register_module("webhooks.docker.update", DockerWebhookModule::class);
 
 foreach(["", ".json", ".yml", ".xml"] as $type) {
     foreach($type === ".yml" ? [""] : ["", ".min"] as $min) {

--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -385,7 +385,7 @@ class DefaultProjectBuilder extends ProjectBuilder {
              * (notice beginning '/' and end '/')
              */
 
-            Lang::myShellExec("docker create --cpus=1 --memory=256M -e PLUGIN_PATH={$pluginPath} --name {$id} pmmp/poggit-phpstan:0.2.1", $stdout, $stderr, $exitCode);
+            Lang::myShellExec("docker create --cpus=1 --memory=256M -e PLUGIN_PATH={$pluginPath} --name {$id} pmmp/poggit-phpstan:latest", $stdout, $stderr, $exitCode);
 
             if($exitCode !== 0) {
                 $status = new PhpstanInternalError();

--- a/src/poggit/webhook/DockerWebhookModule.php
+++ b/src/poggit/webhook/DockerWebhookModule.php
@@ -34,7 +34,7 @@ class DockerWebhookModule extends Module {
             $this->errorAccessDenied();
         }
 
-        Meta::getLog()->v("Docker update data received.");
+        Meta::getLog()->v("Docker webhook secret verified.");
 
         $payload = json_decode(Meta::getInput(), true);
 

--- a/src/poggit/webhook/DockerWebhookModule.php
+++ b/src/poggit/webhook/DockerWebhookModule.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Poggit
+ *
+ * Copyright (C) 2016-2020 Poggit
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace poggit\webhook;
+
+use poggit\Meta;
+use poggit\module\Module;
+use poggit\utils\lang\Lang;
+
+class DockerWebhookModule extends Module {
+    public function output() {
+        if($_SERVER['REQUEST_METHOD'] !== 'POST' or !isset($_GET['key'])){
+            $this->errorNotFound();
+        }
+
+        if($_GET['key'] !== Meta::getSecret("docker.webhookSecret")){
+            $this->errorAccessDenied();
+        }
+
+        Meta::getLog()->v("Docker update data received.");
+
+        $payload = json_decode(Meta::getInput(), true);
+
+        if($payload === null){
+            Meta::getLog()->w("Failed to decode data from docker, data: ".Meta::getInput());
+            $this->errorBadRequest("Invalid data received.");
+        }
+
+        if($payload['repository']['repo_name'] !== "pmmp/poggit-phpstan"){
+            Meta::getLog()->i("Ignoring docker update, repository is not used.");
+            return;
+        }
+
+        if($payload['push_data']['tag'] !== 'latest'){
+            Meta::getLog()->i("Ignoring docker update, tag not latest.");
+            return;
+        }
+
+        Meta::getLog()->i("Updating docker image '{$payload['repository']['repo_name']}' locally, Image updated by '".
+            $payload['push_data']['pusher']."' on '".date('D, d M Y H:i:s', $payload['push_data']['pushed_at'])."'");
+
+        Lang::myShellExec("docker pull pmmp/poggit-phpstan:latest", $stdout, $stderr, $exitCode);
+
+        if($exitCode !== 0){
+            Meta::getLog()->e("Failed to update docker image.\nstderr: {$stderr}\nexitCode: {$exitCode}");
+        } else {
+            // Assuming the push to docker hub was not a 'fake'
+            Meta::getLog()->i("Successfully updated image.");
+        }
+    }
+}

--- a/stub/secret-stub.json
+++ b/stub/secret-stub.json
@@ -50,5 +50,8 @@
         "errorHook": "https://discordapp.com/api/webhooks/3/C",
         "reviewHook": "https://discordapp.com/api/webhooks/4/D",
         "regHook": "https://discordapp.com/api/webhooks/5/E"
+    },
+    "docker": {
+        "webhookSecret": "A long key to use as a parameter in docker webhooks."
     }
 }


### PR DESCRIPTION
Using [docker webhooks](https://docs.docker.com/docker-hub/webhooks/) we can efficiently update images automatically, ~assuming dockers base image update feature
![image](https://user-images.githubusercontent.com/25908768/84569538-4814dc80-ad7f-11ea-8b44-7531cbf43e19.png) works~it works, this will make poggit-phpstan completely automatic in terms of pmmp updating, building and deployment to poggit. 

Unfortunately dockers webhook services are far from custom, only option is URL and no explicit headers are sent to verify payload/sender, simple but only way around that was a key parameter in the webhook URL, right now I can't see how this endpoint could be malicious but for the future where we may depend more on the data being received it may be necessary to confirm sender/payload.

The lovely changes/breaks:
- New docker secret in secrets.json
- Using latest tag for poggit-phpstan