### PR TITLE
Improve virion_infect performance

### DIFF
--- a/assets/php/virion.php
+++ b/assets/php/virion.php
@@ -208,14 +208,14 @@ final class TempDir {
         $this->path = tempnam(sys_get_temp_dir(), "virion-inject");
         unlink($this->path);
         $this->path .= DIRECTORY_SEPARATOR;
-        mkdir($this->path);
+        mkdir($this->path, 0666);
     }
 
     public function addFile(string $path, string $data): void {
         $absolutePath = $this->path . $path;
         if(file_exists($absolutePath)) throw new ErrorException("File $absolutePath already exists");
         $absoluteDirPath = (new \SplFileInfo($absolutePath))->getPath();
-        if(!is_dir($absoluteDirPath)) mkdir($absoluteDirPath, 0777, true);
+        if(!is_dir($absoluteDirPath)) mkdir($absoluteDirPath, 0666, true);
         file_put_contents($absolutePath, $data);
     }
 

--- a/assets/php/virion.php
+++ b/assets/php/virion.php
@@ -215,7 +215,7 @@ final class TempDir {
     public function addFile(string $path, string $data): void {
         $absolutePath = $this->path . $path;
         if(file_exists($absolutePath)) throw new ErrorException("File $absolutePath already exists");
-        $absoluteDirPath = (new \SplFileInfo($absolutePath))->getPath();
+        $absoluteDirPath = dirname($absolutePath);
         if(!is_dir($absoluteDirPath)) mkdir($absoluteDirPath, 0666, true);
         file_put_contents($absolutePath, $data);
     }

--- a/assets/php/virion.php
+++ b/assets/php/virion.php
@@ -207,9 +207,9 @@ final class TempDir {
 
     public function __construct() {
         $this->path = tempnam(sys_get_temp_dir(), "virion-inject");
-        unlink($this->path);
+        if(file_exists($this->path)) unlink($this->path);
         $this->path .= DIRECTORY_SEPARATOR;
-        mkdir($this->path, 0666);
+        if(!is_dir($this->path)) mkdir($this->path, 0666);
     }
 
     public function addFile(string $path, string $data): void {


### PR DESCRIPTION
Significantly improves performance of `virion_infect` by placing changed files in a temporary directory and calling `Phar::buildFromDirectory($temp_dir_path)`. This avoids repackaging phar for every changed file (repackaging happens only during the `Phar::buildFromDirectory` call).

The complexity is reduced from `O(n^2)` all the way to `O(n)` where `n` is the number of files being packaged into `.phar`.