### PR TITLE
More updates for PHP 7.4

### DIFF
--- a/src/poggit/ci/builder/ProjectBuilder.php
+++ b/src/poggit/ci/builder/ProjectBuilder.php
@@ -688,7 +688,7 @@ MESSAGE
                         $status->isHtml = true;
                     } else {
                         $status->code = $lines[$currentLine - 1] ?? "";
-                        $status->hlSects = [$hlSectsPos = stripos($status->code, "echo"), $hlSectsPos + 2];
+                        $status->hlSects[] = [$hlSectsPos = stripos($status->code, "echo"), $hlSectsPos + 2];
                         $status->isHtml = false;
                     }
                     $status->isFileMain = $isFileMain;
@@ -704,7 +704,7 @@ MESSAGE
                     $status->file = $file;
                     $status->line = $line;
                     $status->code = $lines[$line - 1] ?? "";
-                    $status->hlSects = [$classPos = strpos($status->code, $class), $classPos + 2];
+                    $status->hlSects[] = [$classPos = strpos($status->code, $class), $classPos + 2];
                     $status->class = $namespace . "\\" . $class;
                     $result->addStatus($status);
                 }


### PR DESCRIPTION
Seems there was an inconsistency over in ProjectBuilder causing several issues:
- Build left pending on github status if either of the following happened:
- NonPsrLint Created.
- DirectStdOut Created.
- The above would not be shown on projects build page.

Problem:
Correct usage:
https://github.com/poggit/poggit/blob/4bd7b284aac0ffd2eb4de82aecec46eb37bccd90/src/poggit/ci/builder/ProjectBuilder.php#L666
Incorrect usage/inconsistency:
https://github.com/poggit/poggit/blob/4bd7b284aac0ffd2eb4de82aecec46eb37bccd90/src/poggit/ci/builder/ProjectBuilder.php#L691
https://github.com/poggit/poggit/blob/4bd7b284aac0ffd2eb4de82aecec46eb37bccd90/src/poggit/ci/builder/ProjectBuilder.php#L707


When attempting to sort later here:
https://github.com/poggit/poggit/blob/4bd7b284aac0ffd2eb4de82aecec46eb37bccd90/src/poggit/ci/lint/BadPracticeLint.php#L45
It fails due to it being a single array [int] when it should be a 2D array [int][int]


Pre-PHP7.4 the array would remain **unchanged** when a 1D array [] is used whereas in PHP7.4 it would fail. In all version when a 2D array [][] is used it would be sorted accordingly.