### PR TITLE
Update default secret stubs.

### DIFF
--- a/stub/secret-stub.json
+++ b/stub/secret-stub.json
@@ -52,6 +52,7 @@
         "newBuildsHook": "https://discordapp.com/api/webhooks/2/B",
         "errorHook": "https://discordapp.com/api/webhooks/3/C",
         "reviewHook": "https://discordapp.com/api/webhooks/4/D",
-        "regHook": "https://discordapp.com/api/webhooks/5/E"
+        "reviewsHook": "https://discordapp.com/api/webhooks/5/E",
+        "regHook": "https://discordapp.com/api/webhooks/6/F"
     }
 }


### PR DESCRIPTION
Adds the missing reviewsHook added in c696ecc