### PR TITLE
Fix wrong $argv index being used to access prefix in virion_stub.php

### DIFF
--- a/assets/php/virion_stub.php
+++ b/assets/php/virion_stub.php
@@ -81,7 +81,7 @@ $host = new Phar($argv[1]);
 $host->startBuffering();
 
 try {
-    $status = poggit\virion\virion_infect($virus, $host, $argv[3] ?? ("_" . bin2hex(random_bytes(10))), VIRION_INFECTION_MODE_SYNTAX, $hostChanges, $viralChanges);
+    $status = poggit\virion\virion_infect($virus, $host, $argv[2] ?? ("_" . bin2hex(random_bytes(10))), VIRION_INFECTION_MODE_SYNTAX, $hostChanges, $viralChanges);
     echo "Shaded $hostChanges references in host and $viralChanges references in virion.\n";
     if($status !== 0) exit($status);
 } catch(RuntimeException $e) {


### PR DESCRIPTION
Here $argv[3] is being used to access the prefix passed by the user on the CLI.
https://github.com/poggit/poggit/blob/3e8e679a25e410fd5e4bd8181acfe6e1d436ed78/assets/php/virion_stub.php#L84

However, as documented [here](https://github.com/poggit/support/blob/afa324ecbba9a3d5ab4a2fc74f20b32a27fc77ff/virion.md#compiling-a-virion-user-without-poggit), it is supposed to be the second argument passed to the virion PHAR which corresponds to $argv[2] ($argv[0] is the virion PHAR itself, $argv[1] is the target virion user, $argv[2] should be the prefix).
