### PR TITLE
PHP8 Virion support.

### DIFF
--- a/assets/php/virion.php
+++ b/assets/php/virion.php
@@ -154,6 +154,7 @@ function change_dna(string $chromosome, string $antigen, string $antibody, $mode
                             if($id === T_NAME_FULLY_QUALIFIED){
                                 if(strpos($str, "\\" . $antigen) === 0) { // case-sensitive!
                                     $tokens[$offset][1] = "\\" . $antibody . substr($str, strlen($antigen));
+                                    ++$count;
                                 } elseif(stripos($str, "\\" . $antigen) === 0) {
                                     echo "\x1b[38;5;227m\n[WARNING] Not replacing FQN $str case-insensitively.\n\x1b[m";
                                 }

--- a/assets/php/virion.php
+++ b/assets/php/virion.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 
 /*
  * Poggit
@@ -46,7 +46,10 @@ use const T_NS_SEPARATOR;
 use const T_STRING;
 use const T_USE;
 use const T_WHITESPACE;
-const VIRION_BUILDER_VERSION = "1.2";
+use const T_NAME_FULLY_QUALIFIED; //PHP8
+use const T_NAME_QUALIFIED;       //PHP8
+
+const VIRION_BUILDER_VERSION = "1.3";
 
 const VIRION_INFECTION_MODE_SYNTAX = 0;
 const VIRION_INFECTION_MODE_SINGLE = 1;
@@ -136,36 +139,84 @@ function change_dna(string $chromosome, string $antigen, string $antibody, $mode
         case VIRION_INFECTION_MODE_SYNTAX:
             $tokens = token_get_all($chromosome);
             $tokens[] = ""; // should not be valid though
-            foreach($tokens as $offset => $token) {
-                if(!is_array($token) or $token[0] !== T_WHITESPACE) {
-                    /** @noinspection IssetArgumentExistenceInspection */
-                    list($id, $str, $line) = is_array($token) ? $token : [-1, $token, $line ?? 1];
-                    /** @noinspection IssetArgumentExistenceInspection */
-                    if(isset($init, $current, $prefixToken)) {
-                        if($current === "" && $prefixToken === T_USE and $id === T_FUNCTION || $id === T_CONST) {
-                        } elseif($id === T_NS_SEPARATOR || $id === T_STRING) {
-                            $current .= $str;
-                        } elseif(!($current === "" && $prefixToken === T_USE and $id === T_FUNCTION || $id === T_CONST)) {
-                            // end of symbol reference
-                            if(strpos($current, $antigen) === 0) { // case-sensitive!
-                                $new = $antibody . substr($current, strlen($antigen));
-                                for($o = $init + 1; $o < $offset; ++$o) {
-                                    if($tokens[$o][0] === T_NS_SEPARATOR || $tokens[$o][0] === T_STRING) {
-                                        $tokens[$o][1] = $new;
-                                        $new = ""; // will write nothing after the first time
-                                    }
-                                }
-                                ++$count;
-                            } elseif(stripos($current, $antigen) === 0) {
-                                echo "\x1b[38;5;227m\n[WARNING] Not replacing FQN $current case-insensitively.\n\x1b[m";
-                            }
-                            unset($init, $current, $prefixToken);
-                        }
-                    } else {
-                        if($id === T_NS_SEPARATOR || $id === T_NAMESPACE || $id === T_USE) {
+            if(PHP_VERSION_ID >= 80000){
+                //PHP8 Specific, https://wiki.php.net/rfc/namespaced_names_as_token
+                foreach($tokens as $offset => $token) {
+                    if(!is_array($token) or $token[0] !== T_WHITESPACE) {
+                        /** @noinspection IssetArgumentExistenceInspection */
+                        list($id, $str, $line) = is_array($token) ? $token : [-1, $token, $line ?? 1];
+                        if($id === T_NAME_FULLY_QUALIFIED){
                             $init = $offset;
-                            $current = "";
                             $prefixToken = $id;
+                        }
+                        /** @noinspection IssetArgumentExistenceInspection */
+                        if(isset($init, $prefixToken)) {
+                            if($id === T_NAME_FULLY_QUALIFIED){
+                                if(strpos($str, "\\" . $antigen) === 0) { // case-sensitive!
+                                    $tokens[$offset][1] = "\\" . $antibody . substr($str, strlen($antigen));
+                                } elseif(stripos($str, "\\" . $antigen) === 0) {
+                                    echo "\x1b[38;5;227m\n[WARNING] Not replacing FQN $str case-insensitively.\n\x1b[m";
+                                }
+                            } elseif($id === T_NAME_QUALIFIED) {
+                                if(strpos($str, $antigen) === 0) { // case-sensitive!
+                                    $new = $antibody . substr($str, strlen($antigen));
+                                    if($prefixToken === T_NAMESPACE){
+                                        $tokens[$init+2][1] = $new;
+                                    } else{
+                                        //T_USE
+                                        for($o = $init + 1; $o <= $offset; ++$o) {
+                                            if($tokens[$o][0] === T_NAME_QUALIFIED) {
+                                                $tokens[$o][1] = $new;
+                                            }
+                                        }
+                                    }
+                                    ++$count;
+                                } elseif(stripos($str, $antigen) === 0) {
+                                    echo "\x1b[38;5;227m\n[WARNING] Not replacing FQN $str case-insensitively.\n\x1b[m";
+                                }
+                                unset($init, $str, $prefixToken);
+                            }
+                        } else {
+                            if($id === T_NAMESPACE || $id === T_USE) {
+                                $init = $offset;
+                                $prefixToken = $id;
+                            }
+                        }
+                    }
+                }
+            } else{
+                foreach($tokens as $offset => $token) {
+                    if(!is_array($token) or $token[0] !== T_WHITESPACE) {
+                        /** @noinspection IssetArgumentExistenceInspection */
+                        list($id, $str, $line) = is_array($token) ? $token : [-1, $token, $line ?? 1];
+                        /** @noinspection IssetArgumentExistenceInspection */
+                        if(isset($init, $current, $prefixToken)) {
+                            /** @noinspection PhpStatementHasEmptyBodyInspection */
+                            if($current === "" && $prefixToken === T_USE and $id === T_FUNCTION || $id === T_CONST) {
+                            } elseif($id === T_NS_SEPARATOR || $id === T_STRING) {
+                                $current .= $str;
+                            } elseif(!($current === "" && $prefixToken === T_USE and $id === T_FUNCTION || $id === T_CONST)) {
+                                // end of symbol reference
+                                if(strpos($current, $antigen) === 0) { // case-sensitive!
+                                    $new = $antibody . substr($current, strlen($antigen));
+                                    for($o = $init + 1; $o < $offset; ++$o) {
+                                        if($tokens[$o][0] === T_NS_SEPARATOR || $tokens[$o][0] === T_STRING) {
+                                            $tokens[$o][1] = $new;
+                                            $new = ""; // will write nothing after the first time
+                                        }
+                                    }
+                                    ++$count;
+                                } elseif(stripos($current, $antigen) === 0) {
+                                    echo "\x1b[38;5;227m\n[WARNING] Not replacing FQN $current case-insensitively.\n\x1b[m";
+                                }
+                                unset($init, $current, $prefixToken);
+                            }
+                        } else {
+                            if($id === T_NS_SEPARATOR || $id === T_NAMESPACE || $id === T_USE) {
+                                $init = $offset;
+                                $current = "";
+                                $prefixToken = $id;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Thanks to https://wiki.php.net/rfc/namespaced_names_as_token all virions currently built / being built are not usable (for injecting) with PHP8.

As linked the `token_get_all` behaviour changed and from PHP8 gives the namespaces as their own token instead of a collection of strings & separators, it has actually made it much easier to shade instead of collecting pieces of the namespace you have the entire thing at once.

The `T_NAME_FULLY_QUALIFIED`, `\name\space\Clazz` from `\name\space\Clazz::method();` is a bit different from the others in the sense that it only has a single token and no prefix like `T_USE`, `T_NAMESPACE` and so L148 is for that specific case.


Testing,

Tested using it as a standalone script with some sample data from the support docs, see attached for test file and data used along with results on PHP7 & PHP8 binaries.

Note this may not cater for every use but I only tested against what the docs say is allowed and with a simple file not a full on plugin/virion.