### PR TITLE
Fix default lint message.

### DIFF
--- a/src/poggit/ci/builder/ProjectBuilder.php
+++ b/src/poggit/ci/builder/ProjectBuilder.php
@@ -600,7 +600,8 @@ MESSAGE
 
     protected function lintPhpFile(BuildResult $result, string $file, string $contents, bool $isFileMain, $options = []) {
         file_put_contents($this->tempFile, $contents);
-        Lang::myShellExec("php -l " . escapeshellarg($this->tempFile), $stdout, $lint, $exitCode);
+        Lang::myShellExec("php -l " . escapeshellarg($this->tempFile), $lint, $stderr, $exitCode);
+        $lint = trim(str_replace($this->tempFile, $file, $lint));
         if($exitCode !== 0){
             if($options["syntaxError"] ?? true) {
                 $status = new SyntaxErrorLint();


### PR DESCRIPTION
Tested on PHP7 & 8 both use stdout for message not stderr.

No more empty useless lint problems, they now show the relevant message, file and line.
<img width="437" alt="Screenshot 2021-08-05 at 11 35 39" src="https://user-images.githubusercontent.com/25908768/128336416-fc1c5364-9f21-4c15-b887-b4d77db55b77.png">

```
Lint 
Severity: Warning

Syntax error detected in src/brokiem/simplepets/EventListener.php:

Parse error: syntax error, unexpected '->' (T_OBJECT_OPERATOR) in src/brokiem/simplepets/EventListener.php on line 66
Errors parsing src/brokiem/simplepets/EventListener.php
```