### PR TITLE
src-namespace-prefix support in virion injection.

### DIFF
--- a/assets/php/virion.php
+++ b/assets/php/virion.php
@@ -61,12 +61,15 @@ function virion_infect(Phar $virus, Phar $host, string $prefix = "", int $mode =
     if(!is_array($virionYml)) {
         throw new RuntimeException("Corrupted virion.yml, could not activate virion", 2);
     }
-    $hostYml = yaml_parse(file_get_contents($host["plugin.yml"]));
-    if(!is_array($hostYml)) {
-        throw new RuntimeException("Corrupted plugin.yml in host plugin, could not inject virion", 2);
+    $srcNamespacePrefix = "";
+    if(isset($host["plugin.yml"])) {
+        $hostYml = yaml_parse(file_get_contents($host["plugin.yml"]));
+        if(!is_array($hostYml)) {
+            throw new RuntimeException("Corrupted plugin.yml in host plugin, could not inject virion", 2);
+        }
+        $host["plugin.yml"] = yaml_emit($hostYml);
+        $srcNamespacePrefix = str_replace("\\", "/", $hostYml["src-namespace-prefix"] ?? "");
     }
-    $host["plugin.yml"] = yaml_emit($hostYml);
-    $srcNamespacePrefix = str_replace("\\", "/", $hostYml["src-namespace-prefix"] ?? "");
 
     $infectionLog = isset($host["virus-infections.json"]) ? json_decode(file_get_contents($host["virus-infections.json"]), true) : [];
 

--- a/assets/php/virion.php
+++ b/assets/php/virion.php
@@ -45,7 +45,7 @@ use const T_WHITESPACE;
 use const T_NAME_FULLY_QUALIFIED;
 use const T_NAME_QUALIFIED;
 
-const VIRION_BUILDER_VERSION = "1.4";
+const VIRION_BUILDER_VERSION = "1.5";
 
 const VIRION_INFECTION_MODE_SYNTAX = 0;
 const VIRION_INFECTION_MODE_SINGLE = 1;
@@ -61,6 +61,12 @@ function virion_infect(Phar $virus, Phar $host, string $prefix = "", int $mode =
     if(!is_array($virionYml)) {
         throw new RuntimeException("Corrupted virion.yml, could not activate virion", 2);
     }
+    $hostYml = yaml_parse(file_get_contents($host["plugin.yml"]));
+    if(!is_array($hostYml)) {
+        throw new RuntimeException("Corrupted plugin.yml in host plugin, could not inject virion", 2);
+    }
+    $host["plugin.yml"] = yaml_emit($hostYml);
+    $srcNamespacePrefix = str_replace("\\", "/", $hostYml["src-namespace-prefix"] ?? "");
 
     $infectionLog = isset($host["virus-infections.json"]) ? json_decode(file_get_contents($host["virus-infections.json"]), true) : [];
 
@@ -88,6 +94,7 @@ function virion_infect(Phar $virus, Phar $host, string $prefix = "", int $mode =
 
     $hostPharPath = "phar://" . str_replace(DIRECTORY_SEPARATOR, "/", $host->getPath());
     $hostChanges = 0;
+    //Replace all virion namespace references with antibody(injected)namespace references.
     foreach(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($hostPharPath)) as $name => $chromosome) {
         if($chromosome->isDir()) continue;
         if($chromosome->getExtension() !== "php") continue;
@@ -98,7 +105,11 @@ function virion_infect(Phar $virus, Phar $host, string $prefix = "", int $mode =
     }
 
     $restriction = "src/" . str_replace("\\", "/", $antigen) . "/"; // restriction enzyme ^_^
-    $ligase = "src/" . str_replace("\\", "/", $antibody) . "/";
+    $ligase = str_replace("\\", "/", $antibody) . "/";
+    if($srcNamespacePrefix !== "" and str_starts_with($ligase, $srcNamespacePrefix)){
+        $ligase = cut_prefix($ligase, $srcNamespacePrefix."/");
+    }
+    $ligase = "src/" . $ligase;
 
     $viralChanges = 0;
     foreach(new RecursiveIteratorIterator($virus) as $name => $genome) {
@@ -115,7 +126,7 @@ function virion_infect(Phar $virus, Phar $host, string $prefix = "", int $mode =
             } else {
                 $newRel = $ligase . cut_prefix($rel, $restriction);
             }
-            $data = change_dna(file_get_contents($name), $antigen, $antibody, $mode, $viralChanges); // it's actually RNA
+            $data = change_dna(file_get_contents($name), $antigen, ($srcNamespacePrefix === "" ? "" : str_replace("/", "\\", $srcNamespacePrefix)."\\").$antibody, $mode, $viralChanges); // it's actually RNA
             $host[$newRel] = $data;
         }
     }

--- a/assets/php/virion_stub.php
+++ b/assets/php/virion_stub.php
@@ -39,10 +39,6 @@ if(!Phar::running()) {
     echo "[!] Fatal: virion_stub.php should not be executed directly. Run it when it is in a phar file.\n";
     exit(1);
 }
-if(ini_get("phar.readonly")) {
-    echo "[!] Fatal: phar.readonly is on. Please edit the php.ini file, or run this script with 'php -dphar.readonly=0 $argv[0]\n";
-    exit(1);
-}
 
 $cliMap = [];
 if(is_file(Phar::running() . "/cli-map.json")) {
@@ -58,6 +54,11 @@ if(substr($argv[1], -5) !== ".phar") {
     if(isset($cliMap[$argv[1]])) {
         exit (require Phar::running() . "/" . $cliMap[$argv[1]]);
     }
+}
+
+if(ini_get("phar.readonly")) {
+    echo "[!] Fatal: phar.readonly is on. Please edit the php.ini file, or run this script with 'php -dphar.readonly=0 $argv[0]\n";
+    exit(1);
 }
 
 require Phar::running() . "/virion.php";


### PR DESCRIPTION
Note there may be an odd use case in virions that I haven't tested but I have tested virion in virion, virion in plugin both with and without psr-4 code structure.
Also have no clue if a single thing on GitHub uses the single and double mode so I have left them untouched.

Resolves #303 as well, just a simple swap in position of readonly check. 