### PR TITLE
Fix constraint for src-namespace-prefix

### DIFF
--- a/src/poggit/ci/builder/DefaultProjectBuilder.php
+++ b/src/poggit/ci/builder/DefaultProjectBuilder.php
@@ -140,7 +140,8 @@ class DefaultProjectBuilder extends ProjectBuilder {
         $apis = $pluginManifest["api"]??[];
         $usePrefix = false;
         foreach(is_array($apis) ? $apis : [$apis] as $api){
-            if($api[0] === "4"){
+            $majorVersion = explode(".", $api, 2)[0];
+            if(ctype_digit($majorVersion) && (int) $majorVersion >= 4){
                 $usePrefix = true;
             }
         }

--- a/src/poggit/ci/builder/ProjectBuilder.php
+++ b/src/poggit/ci/builder/ProjectBuilder.php
@@ -551,7 +551,8 @@ MESSAGE
         $apis = $manifest["api"];
         $usePrefix = false;
         foreach(is_array($apis) ? $apis : [$apis] as $api){
-            if($api[0] === "4"){
+            $majorVersion = explode(".", $api, 2)[0];
+            if(ctype_digit($majorVersion) && (int) $majorVersion >= 4){
                 $usePrefix = true;
             }
         }


### PR DESCRIPTION
the old code fails on PM5, and would also have caught fire once we reach double-digit major versions