### PR TITLE
Skip all linting if lint: false

### DIFF
--- a/src/poggit/ci/builder/ProjectBuilder.php
+++ b/src/poggit/ci/builder/ProjectBuilder.php
@@ -591,6 +591,7 @@ MESSAGE
     }
 
     protected function lintPhpFile(BuildResult $result, string $file, string $contents, bool $isFileMain, string $srcNamespacePrefix = "", $options = []) {
+        if($options === null) return;
         file_put_contents($this->tempFile, $contents);
         Lang::myShellExec("php -l " . escapeshellarg($this->tempFile), $lint, $stderr, $exitCode);
         $lint = trim(str_replace($this->tempFile, $file, $lint));
@@ -603,8 +604,6 @@ MESSAGE
                 return;
             }
         }
-
-        if($options === null) return;
 
         $lines = explode("\n", $contents);
         $tokens = token_get_all($contents);


### PR DESCRIPTION
Syntax error lints don't get disabled if all other lints get disabled, this PR fixes that.
(In the code snippet below $options are the lint options or null if false was specified)
https://github.com/poggit/poggit/blob/beta/src/poggit/ci/builder/ProjectBuilder.php#L597-L607