### PR TITLE
Fix paginated repo listing for organization owners

### DIFF
--- a/src/poggit/utils/internet/GitHub.php
+++ b/src/poggit/utils/internet/GitHub.php
@@ -162,7 +162,7 @@ final class GitHub {
             }
         }';
         $secondQuery = 'query ($s: Int, $u: String!, $a: String) {
-            user(login: $u) {
+            user: repositoryOwner(login: $u) {
                 repositories(first: $s, after: $a) {
                     pageInfo {
                         endCursor


### PR DESCRIPTION
## PR Description

This PR fixes a bug in Poggit's GitHub GraphQL pagination logic when listing repositories for an owner that is an organization.

## What was broken

When Poggit loads repositories through [`GitHub::listHisRepos()`](https://github.com/poggit/poggit/blob/beta/src/poggit/utils/internet/GitHub.php#L148), the first GraphQL request uses: `repositoryOwner(login: $u)` but the paginated follow-up request used: `user(login: $u)`

That only works for personal GitHub accounts. It fails for organization owners.

Because of that, owners with enough repositories to trigger pagination could hit a server-side failure on page 2+, which then surfaced as a `500` on `ci.project.list`.

## Why this happens

Poggit does not treat the `owner` input as "user only".
The same path is used for generic owners, including organizations:

- [`ProjectListAjax.php`](https://github.com/poggit/poggit/blob/beta/src/poggit/ci/api/ProjectListAjax.php#L36)
- [`UserBuildPage.php`](https://github.com/poggit/poggit/blob/beta/src/poggit/ci/ui/UserBuildPage.php#L45)

The first query was already written correctly for that by using `repositoryOwner(login: $u)` and aliasing it as `user:` so the response still comes back under `data.user`.

The bug was that the second query changed the actual field from `repositoryOwner(...)` to `user(...)`, while the rest of the code still expected the same generic owner behavior and response shape.

## Impact

This fixes repo listing for owners that require pagination.
With the sample config, pagination starts after `meta.curl.perPage = 100` in [`secret-stub.json`](https://github.com/poggit/poggit/blob/beta/stub/secret-stub.json#L25), so the bug is most visible for owners with `101+` repositories.